### PR TITLE
fix: wipeDir fails under Node 10

### DIFF
--- a/src/functions/filesystem/__tests__/makeTempDir.unit.test.ts
+++ b/src/functions/filesystem/__tests__/makeTempDir.unit.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { makeTempDir } from '../makeTempDir';
+import { rmDir } from '../rmDir';
 import { wipeDir } from '../wipeDir';
 
 const baseDir = 'makeTempDir';
@@ -8,7 +9,7 @@ const baseDir = 'makeTempDir';
 /* Create a single directory in which to create any other directories */
 const tmpDir = makeTempDir(baseDir);
 beforeAll(() => fs.existsSync(tmpDir) && wipeDir(tmpDir));
-afterAll(() => fs.existsSync(tmpDir) && fs.rmdirSync(tmpDir, { recursive: true }));
+afterAll(() => fs.existsSync(tmpDir) && rmDir(tmpDir));
 
 describe('makeTempDir(relativePath:string, options)', () => {
   it('should create a temporary directory and return the path to it', () => {

--- a/src/functions/filesystem/rmDir.ts
+++ b/src/functions/filesystem/rmDir.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import util from 'util';
+
+const readDir = util.promisify(fs.readdir);
+const removeDir = util.promisify(fs.rmdir);
+const unlink = util.promisify(fs.unlink);
+
+/* Remove the directory and all its contents */
+export async function rmDir(dirPath: string): Promise<void> {
+
+  if (!fs.existsSync(dirPath)) {
+    return;
+  }
+  const childNames = await readDir(dirPath);
+  await Promise.all(
+    childNames.map(childName => {
+      const childPath = path.join(dirPath, childName);
+      return fs.lstatSync(childPath).isDirectory()
+        ? rmDir(childPath) // recursively call `rmDir` on each directory
+        : unlink(childPath);
+    })
+  );
+  await removeDir(dirPath); // Use the Node `rmDir` function to remove the directory itself
+}

--- a/src/functions/filesystem/wipeDir.ts
+++ b/src/functions/filesystem/wipeDir.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
+import { rmDir } from './rmDir';
 
 type WipeDirOptions = {
   recursive?: boolean;
@@ -9,6 +10,7 @@ type WipeDirOptions = {
 const readdir = util.promisify(fs.readdir);
 const unlink = util.promisify(fs.unlink);
 
+/* Remove the contents of the directory without removing the directory itself */
 export async function wipeDir(dirPath: string, options: WipeDirOptions = {}): Promise<void> {
   const { recursive } = options;
 
@@ -20,7 +22,7 @@ export async function wipeDir(dirPath: string, options: WipeDirOptions = {}): Pr
     childNames.map(childName => {
       const childPath = path.join(dirPath, childName);
       return fs.lstatSync(childPath).isDirectory()
-        ? (recursive ? fs.rmdirSync(childPath, { recursive }) : undefined)
+        ? (recursive ? rmDir(childPath) : undefined)
         : unlink(childPath);
     })
   );


### PR DESCRIPTION
`wipeDir` relies on the `recursive` option of `rmdirSync`, but that option did not exist in Node 10.

This branch replaces the unsupported `rmdirSync(filepath, { recursive })` with a custom `rmDir` function that works under Node 10.
