### PR TITLE
refactor: Narrow values depending on conditional in `includeIf`

### DIFF
--- a/src/functions/array/__tests__/includeIf.unit.test.ts
+++ b/src/functions/array/__tests__/includeIf.unit.test.ts
@@ -50,4 +50,18 @@ describe('includeIf(value)', () => {
     const expected = [1, 2];
     expect(array).toStrictEqual(expected);
   });
+
+  it('should correctly narrow the type of the conditional', () => {
+    interface Query {
+      conditional: string;
+    }
+
+    const conditional = undefined;
+
+    const queries: Query[] = [
+      ...includeIf(conditional, { conditional }),
+    ];
+
+    expect(queries).toHaveLength(0);
+  });
 });

--- a/src/functions/array/includeIf.ts
+++ b/src/functions/array/includeIf.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-type Falsy = undefined | null | '' | 0;
+type Falsy = false | undefined | null | '' | 0;
 type Truthy<T = any> = Exclude<T, Falsy>;
 
 export function includeIf<T extends Falsy>(valueToIncludeIfTruthy: T): [];

--- a/src/functions/array/includeIf.ts
+++ b/src/functions/array/includeIf.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export function includeIf<T>(valueToIncludeIfTruthy: T): T[];
-export function includeIf<T>(conditional: any, value: T): T[];
+type Falsy = undefined | null | '' | 0;
+type Truthy<T = any> = Exclude<T, Falsy>;
+
+export function includeIf<T extends Falsy>(valueToIncludeIfTruthy: T): [];
+export function includeIf<T extends Truthy>(valueToIncludeIfTruthy: T): T[];
+export function includeIf<C extends Falsy, T>(conditional: C, value: T): [];
+export function includeIf<C extends Truthy, T>(conditional: C, value: T): T[];
 
 /* If the condition is truthy, return the value in an array; otherwise, return an empty array; if
    only one argument is received, use it as both the condition and the value


### PR DESCRIPTION
This improves the typings of `includeIf()` by narrowing the type of the returned value. It tells TypeScript, for example, that

- if `conditional` is truthy, the type of `value: T | undefined ` is narrowed to `T`
- if `conditional` is falsy, the returned value is an empty array

This should eliminate the need to add type assertion to the value returned by the function.