### PR TITLE
Fix: Suffix appended by makeTempDir has a trailing brace

### DIFF
--- a/src/functions/array/__tests__/includeIf.unit.test.ts
+++ b/src/functions/array/__tests__/includeIf.unit.test.ts
@@ -60,6 +60,7 @@ describe('includeIf(value)', () => {
 
     const queries: Query[] = [
       ...includeIf(conditional, { conditional }),
+      ...includeIf(false, { conditional }),
     ];
 
     expect(queries).toHaveLength(0);

--- a/src/functions/filesystem/makeTempDir.ts
+++ b/src/functions/filesystem/makeTempDir.ts
@@ -20,7 +20,7 @@ export function makeTempDir(relativePath: string, options: MakeTempDirOptions = 
   const basePaths = toArray(baseDir);
 
   const tmpDir = os.tmpdir();
-  const subDir = addRandomSuffix ? `${relativePath}-${randomAlphanumeric()}}` : relativePath;
+  const subDir = addRandomSuffix ? `${relativePath}-${randomAlphanumeric()}` : relativePath;
   const dirPath = path.join(
     tmpDir,
     ...(basePaths),


### PR DESCRIPTION
- Fixed an issue where the random suffix appended by `makeTempDir` always had a trailing brace
- Added a new check of type narrowing to `includeIf`