### PR TITLE
Fix: `makeTempDir` fails when nested dirs are to be created

### DIFF
--- a/src/functions/filesystem/__tests__/makeTempDir.unit.test.ts
+++ b/src/functions/filesystem/__tests__/makeTempDir.unit.test.ts
@@ -35,4 +35,12 @@ describe('makeTempDir(relativePath:string, options)', () => {
     expect(() => makeTempDir(subDirName, { baseDir })).not.toThrow();
     expect(() => makeTempDir(subDirName, { baseDir, disallowExisting: true })).toThrow();
   });
+
+  it('can created nested directories', () => {
+    const subDirName = 'test3/subdir';
+
+    makeTempDir(subDirName, { baseDir });
+    expect(() => makeTempDir(subDirName, { baseDir })).not.toThrow();
+    expect(() => makeTempDir(subDirName, { baseDir, disallowExisting: true })).toThrow();
+  });
 });

--- a/src/functions/filesystem/makeTempDir.ts
+++ b/src/functions/filesystem/makeTempDir.ts
@@ -32,7 +32,7 @@ export function makeTempDir(relativePath: string, options: MakeTempDirOptions = 
       throw new Error(`The subdirectory '${relativePath}' already exists`);
     }
   } else {
-    fs.mkdirSync(dirPath);
+    fs.mkdirSync(dirPath, { recursive: true });
   }
   return dirPath;
 }


### PR DESCRIPTION
Fixed by setting `recursive: true` in the options passed to `fs.mkDirSync`
