### PR TITLE
Refactor: Improve typing of `isObject`

### DIFF
--- a/src/functions/object/__tests__/isObject.unit.test.ts
+++ b/src/functions/object/__tests__/isObject.unit.test.ts
@@ -1,0 +1,53 @@
+import { isObject } from '../isObject';
+
+describe('isObject(value: any)', () => {
+  it('should return false if the value is any primitive', () => {
+    const primitives = [true, false, 0, 1, '', 'non-empty-string'];
+    for (const primitive of primitives) {
+      expect(isObject(primitive)).toBe(false);
+    }
+  });
+
+  it('should return false if the value is null', () => {
+    expect(isObject(null)).toBe(false);
+  });
+
+  it('should return true if the value is a function', () => {
+    const fn = (): void => void 0;
+    expect(isObject(fn)).toBe(true);
+  });
+
+  it('should return true if the value is an array', () => {
+    expect(isObject([])).toBe(true);
+  });
+
+  it('should return true for any class instance', () => {
+    class MyClass {
+      constructor(public prop?: unknown) {}
+    }
+
+    const instances = [
+      new Date(),
+      new Map(),
+      new MyClass(),
+      new Object(),
+      new Set(),
+      new WeakMap(),
+    ];
+    for (const instance of instances) {
+      expect(isObject(instance)).toBe(true);
+    }
+  });
+
+  it('should return true for an object instantiated with Object.create()', () => {
+    const created = Object.create({ a: 1 });
+    expect(isObject(created)).toBe(true);
+  });
+
+  it('should return true for any other object', () => {
+    const plainObjects = [{}, { a: 1 }];
+    for (const plainObject of plainObjects) {
+      expect(isObject(plainObject)).toBe(true);
+    }
+  });
+});

--- a/src/functions/object/isObject.ts
+++ b/src/functions/object/isObject.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
-export function isObject(value: any): boolean {
-  return typeof value === 'object'
-    ? value !== null
-    : typeof value === 'function';
+export function isObject(value: unknown): value is object {
+  return (typeof value === 'object' && value !== null) || typeof value === 'function';
 }


### PR DESCRIPTION
- Changed the type of the input from `any` to `unknown`
- Changed the `boolean` return value to a type predicate
- Added tests