### PR TITLE
Feature: Can slugify ISO date-time strings with optional truncation

### DIFF
--- a/src/__tests__/verify-exports.app.test.ts
+++ b/src/__tests__/verify-exports.app.test.ts
@@ -24,6 +24,7 @@ const intendedExports: string[] = [
   /* Date & time functions */
   'isValidDate',
   'sleep',
+  'slugifyIsoDateTime',
   'toUnixTime',
   'truncateIsoDateTime',
 

--- a/src/functions/date/__tests__/slugifyIsoDateTime.unit.test.ts
+++ b/src/functions/date/__tests__/slugifyIsoDateTime.unit.test.ts
@@ -1,50 +1,59 @@
 import { slugifyIsoDateTime } from '../slugifyIsoDateTime';
 
-const isoDateTimes = [
-  '1989-01-28T01:02:03.456Z',
-  '1989-01-28T01:02:03Z',
-  '1989-01-28T01:02Z',
-];
+const isoDateTime = '1989-01-28T01:02:03.456Z';
+const resolutions = [
+  'day',
+  'hour',
+  'minute',
+  'second',
+  'millisecond',
+] as const;
 
 describe('slugifyIsoDateTime', () => {
   it("using the default ('slug') preset, should use _ as the date-time separator and - as the unit separator", () => {
-    const expecteds = [
-      '1989-01-28-010203.456', // unlikely to be used
-      '1989-01-28-010203',
-      '1989-01-28-0102',
-    ];
+    const expecteds = {
+      day: '1989-01-28',
+      hour: '1989-01-28-01',
+      minute: '1989-01-28-0102',
+      second: '1989-01-28-010203',
+      millisecond: '1989-01-28-010203.456',
+    };
 
-    isoDateTimes.forEach((isoDateTime, index) => {
-      const simplified = slugifyIsoDateTime(isoDateTime, 'slug');
-      const expected = expecteds[index];
+    resolutions.forEach(dateTimeResolution => {
+      const simplified = slugifyIsoDateTime(isoDateTime, { dateTimeResolution, preset: 'slug' });
+      const expected = expecteds[dateTimeResolution];
       expect(simplified).toBe(expected);
     });
   });
 
   it("using the 'humanize' preset, should use - as the date-time separator and h m s as unit indicators", () => {
-    const expecteds = [
-      '1989-01-28-01h02m03s456',
-      '1989-01-28-01h02m03s',
-      '1989-01-28-01h02m',
-    ];
+    const expecteds = {
+      day: '1989-01-28',
+      hour: '1989-01-28-01h',
+      minute: '1989-01-28-01h02m',
+      second: '1989-01-28-01h02m03s',
+      millisecond: '1989-01-28-01h02m03s456',
+    };
 
-    isoDateTimes.forEach((isoDateTime, index) => {
-      const simplified = slugifyIsoDateTime(isoDateTime, 'humanize');
-      const expected = expecteds[index];
+    resolutions.forEach(dateTimeResolution => {
+      const simplified = slugifyIsoDateTime(isoDateTime, { dateTimeResolution, preset: 'humanize' });
+      const expected = expecteds[dateTimeResolution];
       expect(simplified).toBe(expected);
     });
   });
 
   it("using the 'compact' preset, should strip out nondigits & separate date from time with a hyphen", () => {
-    const expecteds = [
-      '19890128-010203456',
-      '19890128-010203',
-      '19890128-0102',
-    ];
+    const expecteds = {
+      day: '19890128',
+      hour: '19890128-01',
+      minute: '19890128-0102',
+      second: '19890128-010203',
+      millisecond: '19890128-010203456',
+    };
 
-    isoDateTimes.forEach((isoDateTime, index) => {
-      const simplified = slugifyIsoDateTime(isoDateTime, 'compact');
-      const expected = expecteds[index];
+    resolutions.forEach(dateTimeResolution => {
+      const simplified = slugifyIsoDateTime(isoDateTime, { dateTimeResolution, preset: 'compact' });
+      const expected = expecteds[dateTimeResolution];
       expect(simplified).toBe(expected);
     });
   });

--- a/src/functions/date/__tests__/slugifyIsoDateTime.unit.test.ts
+++ b/src/functions/date/__tests__/slugifyIsoDateTime.unit.test.ts
@@ -1,0 +1,57 @@
+import { slugifyIsoDateTime } from '../slugifyIsoDateTime';
+
+const isoDateTimes = [
+  '1989-01-28T01:02:03.456Z',
+  '1989-01-28T01:02:03Z',
+  '1989-01-28T01:02Z',
+];
+
+describe('slugifyIsoDateTime', () => {
+  it("using the default ('slug') preset, should use _ as the date-time separator and - as the unit separator", () => {
+    const expecteds = [
+      '1989-01-28-010203.456', // unlikely to be used
+      '1989-01-28-010203',
+      '1989-01-28-0102',
+    ];
+
+    isoDateTimes.forEach((isoDateTime, index) => {
+      const simplified = slugifyIsoDateTime(isoDateTime, 'slug');
+      const expected = expecteds[index];
+      expect(simplified).toBe(expected);
+    });
+  });
+
+  it("using the 'humanize' preset, should use - as the date-time separator and h m s as unit indicators", () => {
+    const expecteds = [
+      '1989-01-28-01h02m03s456',
+      '1989-01-28-01h02m03s',
+      '1989-01-28-01h02m',
+    ];
+
+    isoDateTimes.forEach((isoDateTime, index) => {
+      const simplified = slugifyIsoDateTime(isoDateTime, 'humanize');
+      const expected = expecteds[index];
+      expect(simplified).toBe(expected);
+    });
+  });
+
+  it("using the 'compact' preset, should strip out nondigits & separate date from time with a hyphen", () => {
+    const expecteds = [
+      '19890128-010203456',
+      '19890128-010203',
+      '19890128-0102',
+    ];
+
+    isoDateTimes.forEach((isoDateTime, index) => {
+      const simplified = slugifyIsoDateTime(isoDateTime, 'compact');
+      const expected = expecteds[index];
+      expect(simplified).toBe(expected);
+    });
+  });
+
+  it("given the special 'now' date-time string, should use the current time", () => {
+    const slugified = slugifyIsoDateTime('now');
+    const pattern = /[0-9]{4}-[0-9]{2}-[0-9]{2}/;
+    expect(pattern.test(slugified)).toBe(true);
+  });
+});

--- a/src/functions/date/index.ts
+++ b/src/functions/date/index.ts
@@ -1,5 +1,6 @@
 export { isValidDate } from './isValidDate';
 export { sleep } from './sleep';
+export { slugifyIsoDateTime } from './slugifyIsoDateTime';
 export { toUnixTime } from './toUnixTime';
 export type { JsTimestamp, UnixTimestamp } from './toUnixTime';
 export { truncateIsoDateTime } from './truncateIsoDateTime';

--- a/src/functions/date/slugifyIsoDateTime.ts
+++ b/src/functions/date/slugifyIsoDateTime.ts
@@ -1,0 +1,53 @@
+import { includeIf } from '../array';
+
+type PresetCode = 'compact' | 'humanize' | 'slug';
+type TransformIsoDateTime = (isoDateTime: string) => string;
+
+
+const presetMap = new Map<PresetCode, TransformIsoDateTime>([
+  [
+    'compact',
+    (isoDateTime: string) => isoDateTime
+      .replace(/[-:Z.]/g, '')
+      .replace('T', '-'),
+  ],
+  [
+    'humanize',
+    (isoDateTime: string) => {
+      const [date, time] = isoDateTime.replace('Z', '').split('T');
+      const [h, m = '', seconds = ''] = time.split(':');
+      const [s, ms = ''] = seconds.split('.');
+      return [
+        date, '-',
+        `${h}h`,
+        ...includeIf(m, `${m}m`),
+        ...includeIf(s, `${s}s`),
+        ms,
+      ].join('');
+    },
+  ],
+  [
+    'slug',
+    (isoDateTime: string) => isoDateTime
+      .replace(/[Z:]/g, '')
+      .replace(/[T]/g, '-'),
+  ],
+]);
+
+export function slugifyIsoDateTime(isoDateTime: string, presetCode: PresetCode = 'slug'): string {
+  const resolvedDateTime = isoDateTime === 'now'
+    ? new Date().toISOString()
+    : isoDateTime;
+
+  // Validate the input
+  const isoDateTimePattern = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}(:[0-9]{2}(:[0-9]{2}(.[0-9]{1,3})?)?)?Z$/;
+  if (!isoDateTimePattern.test(resolvedDateTime)) {
+    throw new Error(`Invalid ISO date time: '${isoDateTime}'`);
+  }
+
+  const transform = presetMap.get(presetCode);
+  if (!transform) {
+    throw new Error(`Unrecognized preset code: '${presetCode}'`);
+  }
+  return transform(resolvedDateTime);
+}


### PR DESCRIPTION
Added the `slugifyIsoDateTime` function, which can convert an ISO date-time string into three different formats, optionally truncating to the desired resolution (e.g., discarding milliseconds).