### PR TITLE
Feature: Formatting of content written by writeDataFile can be customized

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "test": "jest",
     "typecheck": "tsc"
   },
-  "dependencies": {},
+  "dependencies": {
+    "json-beautify": "^1.1.1"
+  },
   "devDependencies": {
     "@skypilot/common-types": "^2.1.5",
     "@skypilot/toolchain": "^5.1.4"

--- a/src/functions/filesystem/writeDataFile.ts
+++ b/src/functions/filesystem/writeDataFile.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { JsonValue } from '@skypilot/common-types';
-import { prettify } from 'src/functions/string/prettify';
+import { beautify } from 'src/functions/string/beautify';
+import type { BeautifyOptions } from 'src/functions/string/beautify';
 import { pushIf } from '../array';
 import { slugifyDateTime } from '../date/slugifyDateTime';
 import type { SlugifyDateTimeOptions, SlugifyDateTimePresetCode } from '../date/slugifyDateTime';
@@ -10,11 +10,12 @@ import { wipeDir } from './wipeDir';
 
 export type WriteDataFileOptions = {
   basePath?: string;
+  beautifyOptions?: BeautifyOptions;
   dateTimeFormat?: SlugifyDateTimeOptions | SlugifyDateTimePresetCode;
-  overwrite?: boolean;
   dryRun?: boolean;
   identifier?: string;
   label?: string;
+  overwrite?: boolean;
   verbose?: boolean;
   wipeDir?: boolean;
 }
@@ -32,7 +33,7 @@ export type WriteDataFileResult<T> = {
 }
 
 /* Given a blob of data, write it to a standardized location under a standardized file name. */
-export async function writeDataFile<T extends JsonValue>(
+export async function writeDataFile<T>(
   data: T, filePath: string, options: WriteDataFileOptions = {}
 ): Promise<WriteDataFileResult<T>> {
   if (!filePath) {
@@ -45,6 +46,7 @@ export async function writeDataFile<T extends JsonValue>(
 
   const {
     basePath = '',
+    beautifyOptions,
     dateTimeFormat,
     dryRun,
     identifier,
@@ -95,7 +97,7 @@ export async function writeDataFile<T extends JsonValue>(
         return Promise.reject(new Error(`The file '${shortestPath}' already exists`));
       }
     }
-    await fs.promises.writeFile(finalFilePath, prettify(data), { encoding: 'utf-8' });
+    await fs.promises.writeFile(finalFilePath, beautify(data, beautifyOptions), { encoding: 'utf-8' });
   }
 
   const descriptionElements: string[] = [];

--- a/src/functions/string/__tests__/beautify.unit.test.ts
+++ b/src/functions/string/__tests__/beautify.unit.test.ts
@@ -1,0 +1,60 @@
+import { beautify } from '../beautify';
+
+describe('beautify()', () => {
+  it('given an object should return its stringified version with a spacing of 2', () => {
+    const input = { a: 1, b: 2 };
+    const expected = '{ "a": 1, "b": 2 }';
+
+    const beautified = beautify(input);
+
+    expect(beautified).toBe(expected);
+  });
+
+  it('when the space value is given, should use that value for spacing', () => {
+    const input = {
+      a: '1'.repeat(80), // Use a long string so that the object displays on multiple lines
+      b: 2,
+    };
+    const expected = [
+      '{',
+      `    "a": "${'1'.repeat(80)}",`,
+      '    "b": 2',
+      '}',
+    ].join('\n');
+
+    const beautified = beautify(input, { space: 4 });
+
+    expect(beautified).toBe(expected);
+  });
+
+  it('when an array is provided as the replacer, should discard keys not in the array', () => {
+    const input = {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+    };
+    const expected = '{ "b": 2, "d": 4 }';
+
+    const beautified = beautify(input, { replacer: ['b', 'd'] });
+
+    expect(beautified).toBe(expected);
+  });
+
+  it('when the maxWidth value is given, should split lines whose length exceeds that value', () => {
+    const input = {
+      a: '1'.repeat(20), // Use a long string so that the object displays on multiple lines
+      b: 2,
+    };
+    const expected = [
+      '{',
+      `  "a": "${'1'.repeat(20)}",`,
+      '  "b": 2',
+      '}',
+    ].join('\n');
+
+    const beautified = beautify(input, { maxWidth: 20 });
+
+    expect(beautified).toBe(expected);
+  });
+});

--- a/src/functions/string/beautify.ts
+++ b/src/functions/string/beautify.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+import jsonBeautify from 'json-beautify';
+import { Integer, Json } from '@skypilot/common-types';
+
+export interface BeautifyOptions {
+  maxWidth?: Integer;
+  replacer?: string[] | ((key: string, value: any) => any);
+  space?: Integer;
+}
+
+export function beautify(data: any, options: BeautifyOptions = {}): Json {
+  const { maxWidth = 80, replacer, space = 2 } = options;
+  // @ts-ignore // ignore the erroneous typing in `json-beautify`
+  return jsonBeautify(data, replacer, space, maxWidth);
+}

--- a/src/functions/string/prettify.ts
+++ b/src/functions/string/prettify.ts
@@ -1,5 +1,8 @@
 import { Json, JsonValue } from '@skypilot/common-types';
 
+/**
+ * @deprecated Use `beautify` instead
+ */
 export function prettify(data: JsonValue): Json {
   return JSON.stringify(data, undefined, 2);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,6 +4455,11 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+json-beautify@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/json-beautify/-/json-beautify-1.1.1.tgz#8a1ed511ad5d52ca63ed29f7c61896c6a6ebbb9f"
+  integrity sha512-17j+Hk2lado0xqKtUcyAjK0AtoHnPSIgktWRsEXgdFQFG9UnaGw6CHa0J7xsvulxRpFl6CrkDFHght1p5ZJc4A==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"


### PR DESCRIPTION
- `writeDataFile` now accepts a `beautifyOptions` option, which allows customization of JSON-stringified outpt
- Added the function `beautify`, a more flexible version of `prettify`, and marked the latter deprecated