### PR TITLE
Export LogLevel type & log-level strings

### DIFF
--- a/src/classes/index.ts
+++ b/src/classes/index.ts
@@ -1,1 +1,2 @@
+export type { LogLevel } from './ValidationResult';
 export { ValidationResult } from './ValidationResult';


### PR DESCRIPTION
- Exposed log levels at `ValidationResult.logLevels`
- Exposed a comparison function at `ValidationResult.compareLevels`
- Exported the `LogLevel` type
