### PR TITLE
Feature: Can time-stamp a temporary directory name

### DIFF
--- a/src/functions/filesystem/__tests__/makeTempDir.unit.test.ts
+++ b/src/functions/filesystem/__tests__/makeTempDir.unit.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+
 import { makeTempDir } from '../makeTempDir';
 import { rmDir } from '../rmDir';
 import { wipeDir } from '../wipeDir';
@@ -18,6 +19,15 @@ describe('makeTempDir(relativePath:string, options)', () => {
 
     expect(subDirPath).toBe(path.resolve(tmpDir, subDirPath));
     expect(subDirPath.endsWith(subDirName)).toBe(true);
+  });
+
+  it('when a dateTimeFormat is given, should add a timestamp to the directory name', () => {
+    const relativeDirName = 'random';
+    const subDirPath = makeTempDir(relativeDirName, { baseDir, dateTimeFormat: 'compact' });
+    const subDirName = path.basename(subDirPath);
+
+    expect(subDirPath.startsWith(path.join(tmpDir, subDirName))).toBe(true);
+    expect(subDirName).toMatch(/random_[0-9]{8}-[0-9]{6}/);
   });
 
   it('when `addRandomSuffix:true`, should add a random suffix to the name of the directory', () => {

--- a/src/functions/filesystem/makeTempDir.ts
+++ b/src/functions/filesystem/makeTempDir.ts
@@ -1,13 +1,18 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+
 import { toArray } from '../array';
+import { DateTimeStampOptions, DateTimeStampPresetCode, makeDateTimeStamp } from '../date';
 import { randomAlphanumeric } from '../string';
+import { composeFileName } from './composeFileName';
 
 interface MakeTempDirOptions {
-  baseDir?: string | string[];
-  disallowExisting?: boolean;
   addRandomSuffix?: boolean;
+  baseDir?: string | string[];
+  dateTimeFormat?: DateTimeStampPresetCode | DateTimeStampOptions | null | undefined;
+  disallowExisting?: boolean;
+  separator?: string;
 }
 
 export function makeTempDir(relativePath: string, options: MakeTempDirOptions = {}): string {
@@ -16,20 +21,24 @@ export function makeTempDir(relativePath: string, options: MakeTempDirOptions = 
     throw new Error('The relative path cannot be an empty string');
   }
 
-  const { baseDir = [], disallowExisting, addRandomSuffix } = options;
+  const { baseDir = [], dateTimeFormat, disallowExisting, addRandomSuffix, separator = '_' } = options;
   const basePaths = toArray(baseDir);
 
   const tmpDir = os.tmpdir();
-  const subDir = addRandomSuffix ? `${relativePath}-${randomAlphanumeric()}` : relativePath;
-  const dirPath = path.join(
+  const subDir = composeFileName([
+    relativePath,
+    ...(dateTimeFormat ? [makeDateTimeStamp(dateTimeFormat)] : []),
+    ...(addRandomSuffix ? [randomAlphanumeric()] : []),
+  ], { separator });
+  const dirPath = path.resolve(
     tmpDir,
-    ...(basePaths),
+    ...basePaths,
     subDir
   );
 
   if (fs.existsSync(dirPath)) {
     if (disallowExisting) {
-      throw new Error(`The subdirectory '${relativePath}' already exists`);
+      throw new Error(`The subdirectory '${subDir}' already exists`);
     }
   } else {
     fs.mkdirSync(dirPath, { recursive: true });


### PR DESCRIPTION
`makeTempDir` now accepts a `dateTimeFormat` option; if set, the generated directory path will include a time stamp in that format
