### PR TITLE
Refine types of values returned by omit* functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   },
   "devDependencies": {
     "@skypilot/common-types": "^2.3.0",
-    "@skypilot/toolchain": "^5.2.3"
+    "@skypilot/toolchain": "^5.2.3",
+    "type-fest": "^1.1.1"
   },
   "engines": {
     "node": ">=12.13.0"

--- a/src/functions/object/__tests__/omitEmptyArrays.unit.test.ts
+++ b/src/functions/object/__tests__/omitEmptyArrays.unit.test.ts
@@ -10,6 +10,16 @@ describe('omitEmptyArrays()', () => {
     expect(noEmpty).toStrictEqual(expected);
   });
 
+  it('given an object without empty arrays, should return a copy of the original object', () => {
+    const obj = { a: 1, b: ['not empty'] };
+    const expected = { a: 1, b: ['not empty'] };
+
+    const noEmpty = omitEmptyArrays(obj);
+
+    expect(noEmpty).toStrictEqual(expected);
+    expect(noEmpty).not.toBe(obj);
+  });
+
   it('if all entries are removed, should return an empty object', () => {
     const obj = { items: [] };
     const expected = {};

--- a/src/functions/object/__tests__/omitFalsy.unit.test.ts
+++ b/src/functions/object/__tests__/omitFalsy.unit.test.ts
@@ -2,7 +2,7 @@ import { omitFalsy } from '../omitFalsy';
 
 describe('omitFalsy(:object)', () => {
   it('given an object, should return a new object having only the truthy values of the original', () => {
-    const originalObj = { a: 1, b: null, c: undefined };
+    const originalObj = { a: 1, b: null, c: undefined, d: 0, e: '' };
 
     const noFalsy = omitFalsy(originalObj);
 

--- a/src/functions/object/omitByValue.ts
+++ b/src/functions/object/omitByValue.ts
@@ -1,10 +1,12 @@
 // TODO: Optionally, recursively omit nested entries having the value
 
+import { JsonObject } from 'type-fest';
+
 /**
  * @description Remove keys whose values have the given value and return as a new object
  */
-export function omitByValue<T extends Record<string, TValues>, TValues>(
-  value: unknown, obj: T
+export function omitByValue<T extends JsonObject, V>(
+  value: V, obj: T
 ): Partial<T> {
   return Object.entries(obj).reduce((compactedObj, entry) => {
     const [key, entryValue] = entry;

--- a/src/functions/object/omitEmptyArrays.ts
+++ b/src/functions/object/omitEmptyArrays.ts
@@ -1,12 +1,10 @@
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-type Dict<Value = any> = Record<string, Value>;
+import type { ConditionalExcept, JsonObject } from 'type-fest';
 
 // TODO: Make this function optionally recursive
 
-// NOTE: Taken from `measurement-api` repo
-
 /* Given an object, return a new object without any entries whose values are empty arrays */
-export function omitEmptyArrays<O extends Dict>(obj: O): Partial<O> {
+export function omitEmptyArrays<O extends JsonObject>(obj: O): ConditionalExcept<O, []> {
   return Object.entries(obj).reduce((accObj, [key, value]) => {
     if (Array.isArray(value) && !value.length) {
       return accObj;
@@ -15,5 +13,5 @@ export function omitEmptyArrays<O extends Dict>(obj: O): Partial<O> {
       ...accObj,
       [key]: value,
     };
-  }, {} as Partial<O>);
+  }, {} as ConditionalExcept<O, []>);
 }

--- a/src/functions/object/omitFalsy.ts
+++ b/src/functions/object/omitFalsy.ts
@@ -3,10 +3,15 @@
   TODO: Optionally, recursively omit nested entries with falsy values.
  */
 
+import { Falsy } from '@skypilot/common-types';
+import { ConditionalExcept, JsonObject } from 'type-fest';
+
+type NoFalsy<T> = ConditionalExcept<T, Falsy>
+
 /**
  * @description Remove keys whose values are falsy and return as a new object
  */
-export function omitFalsy<T extends Record<string, V>, V>(obj: T): Partial<T> {
+export function omitFalsy<T extends JsonObject>(obj: T): NoFalsy<T> {
   return Object.entries(obj).reduce((compactedObj, entry) => {
     const [key, value] = entry;
     if (!value) {
@@ -16,5 +21,5 @@ export function omitFalsy<T extends Record<string, V>, V>(obj: T): Partial<T> {
       ...compactedObj,
       [key]: value,
     };
-  }, {} as Partial<T>);
+  }, {} as NoFalsy<T>);
 }

--- a/src/functions/object/omitUndefined.ts
+++ b/src/functions/object/omitUndefined.ts
@@ -3,11 +3,22 @@
   TODO: Optionally, recursively omit nested entries with undefined values.
  */
 
-import { omitByValue } from './omitByValue';
+import { ConditionalExcept, JsonObject } from 'type-fest';
+
+import { isUndefined } from '../indefinite';
 
 /**
  * @description Remove keys whose values have the given value and return as a new object
  */
-export function omitUndefined<T extends Record<string, V>, V>(obj: T): Partial<T> {
-  return omitByValue(undefined, obj);
+export function omitUndefined<O extends JsonObject>(obj: O): ConditionalExcept<O, undefined> {
+  return Object.entries(obj).reduce((acc, entry) => {
+    const [key, value] = entry;
+    if (isUndefined(value) ) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [key]: value,
+    };
+  }, {} as ConditionalExcept<O, undefined>);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6159,6 +6159,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.1.1.tgz#210251e7f57357a1457269e6b34837fed067ac2c"
+  integrity sha512-RPDKc5KrIyKTP7Fk75LruUagqG6b+OTgXlCR2Z0aQDJFeIvL4/mhahSEtHmmVzXu4gmA0srkF/8FCH3WOWxTWA==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"


### PR DESCRIPTION
`omitEmptyArrays`, `omitFalsy` and `omitUndefined` now narrow their return types to exclude the omitted values