### PR TITLE
feat: Add shortcut methods to ValidationResult

### DIFF
--- a/src/classes/__tests__/ValidationResult.unit.test.ts
+++ b/src/classes/__tests__/ValidationResult.unit.test.ts
@@ -1,11 +1,11 @@
 import { ValidationResult } from '../ValidationResult';
 
 describe('ValidationResult()', () => {
-  describe('add()', () => {
+  describe('addEvent()', () => {
     it('should add the event to the ValidationResult', () => {
       const vr = new ValidationResult();
 
-      vr.add('error', 'An error occurred');
+      vr.addEvent('error', 'An error occurred');
 
       expect(vr.events).toHaveLength(1);
       expect(vr.events[0]).toMatchObject({
@@ -48,7 +48,7 @@ describe('ValidationResult()', () => {
   describe('errors', () => {
     it("should be an alias for getEvents('error')", () => {
       const vr = new ValidationResult();
-      vr.add('error', 'Error event');
+      vr.error('Error event');
 
       expect(vr.getEvents('error')).toStrictEqual(vr.errors);
     });
@@ -57,16 +57,16 @@ describe('ValidationResult()', () => {
   describe('getEvents()', () => {
     it('should return all events', () => {
       const vr = new ValidationResult();
-      vr.add('info', 'Info event');
-      vr.add('debug', 'Debug event');
+      vr.info( 'Info event');
+      vr.debug('Debug event');
 
       expect(vr.getEvents()).toHaveLength(2);
     });
 
     it('if logLevel is given, should return events only of that level', () => {
       const vr = new ValidationResult();
-      vr.add('info', 'Info event');
-      vr.add('debug', 'Debug event');
+      vr.info('Info event');
+      vr.debug('Debug event');
 
       expect(vr.getEvents('debug')).toHaveLength(1);
     });
@@ -75,10 +75,10 @@ describe('ValidationResult()', () => {
   describe('getMessages()', () => {
     it('should return the messages from the events', () => {
       const vr = new ValidationResult();
-      vr.add('debug', 'Debug event');
-      vr.add('error', 'Error event');
-      vr.add('info', 'Info event');
-      vr.add('warn', 'Warn event');
+      vr.addEvent('debug', 'Debug event');
+      vr.addEvent('error', 'Error event');
+      vr.addEvent('info', 'Info event');
+      vr.addEvent('warn', 'Warn event');
 
       expect(vr.getMessages()).toStrictEqual([
         'Debug: Debug event',
@@ -90,8 +90,8 @@ describe('ValidationResult()', () => {
 
     it('if logLevel is given, should return messages only of that level', () => {
       const vr = new ValidationResult();
-      vr.add('warn', 'Warn event');
-      vr.add('error', 'Error event');
+      vr.addEvent('warn', 'Warn event');
+      vr.addEvent('error', 'Error event');
 
       expect(vr.getMessages('error')).toStrictEqual([
         'Error: Error event',
@@ -102,9 +102,9 @@ describe('ValidationResult()', () => {
   describe('errorMessages, warnMessages', () => {
     it('should return the array of corresponding messages', () => {
       const vr = new ValidationResult();
-      vr.add('error', 'Error event 1');
-      vr.add('warn', 'Warn event');
-      vr.add('error', 'Error event 2');
+      vr.addEvent('error', 'Error event 1');
+      vr.addEvent('warn', 'Warn event');
+      vr.addEvent('error', 'Error event 2');
 
       expect(vr.errorMessages).toStrictEqual([
         'Error: Error event 1',
@@ -124,7 +124,7 @@ describe('ValidationResult()', () => {
   describe('has(:LogLevel)', () => {
     it('should return true if there are any events', () => {
       const vr = new ValidationResult();
-      vr.add('info', 'Info event');
+      vr.addEvent('info', 'Info event');
       expect(vr.has()).toBe(true);
     });
 
@@ -135,7 +135,7 @@ describe('ValidationResult()', () => {
 
     it('if logLevel is given, should ignore events having a different level', () => {
       const vr = new ValidationResult();
-      vr.add('info', 'Info event');
+      vr.addEvent('info', 'Info event');
 
       expect(vr.has()).toBe(true);
       expect(vr.has('info')).toBe(true);
@@ -150,7 +150,7 @@ describe('ValidationResult()', () => {
 
     it('if logLevel is given, should return false if there are no events of that level', () => {
       const vr = new ValidationResult();
-      vr.add('info', 'Info event');
+      vr.addEvent('info', 'Info event');
 
       expect(vr.has('info')).toBe(true);
       const absentLogLevels = ['debug', 'error', 'warn'] as const;
@@ -161,8 +161,8 @@ describe('ValidationResult()', () => {
 
     it('if logLevel is given, should return true if there are any events of that level', () => {
       const vr = new ValidationResult();
-      vr.add('info', 'Info event');
-      vr.add('warn', 'Warn event');
+      vr.addEvent('info', 'Info event');
+      vr.addEvent('warn', 'Warn event');
 
       expect(vr.has('error')).toBe(false);
     });
@@ -172,9 +172,9 @@ describe('ValidationResult()', () => {
     it('should return the highest level among all events', () => {
       const vr = new ValidationResult();
 
-      vr.add('info', 'Info event');
-      vr.add('warn', 'Warn event');
-      vr.add('debug', 'Debug event');
+      vr.addEvent('info', 'Info event');
+      vr.addEvent('warn', 'Warn event');
+      vr.addEvent('debug', 'Debug event');
 
       expect(vr.highestLevel).toBe('warn');
     });
@@ -189,8 +189,8 @@ describe('ValidationResult()', () => {
   describe('messages', () => {
     it('should return the array of all messages', () => {
       const vr = new ValidationResult();
-      vr.add('error', 'Error event');
-      vr.add('debug', 'Debug event');
+      vr.addEvent('error', 'Error event');
+      vr.addEvent('debug', 'Debug event');
 
       expect(vr.messages).toStrictEqual([
         'Error: Error event',
@@ -204,26 +204,26 @@ describe('ValidationResult()', () => {
     });
   });
 
-  describe('success', () => {
-    it('should return true if no message were added', () => {
+  describe('ok', () => {
+    it('should return true if no messages were added', () => {
       const vr = new ValidationResult();
-      expect(vr.success).toBe(true);
+      expect(vr.ok).toBe(true);
     });
 
     it('should return true if no errors occurred', () => {
       const vr = new ValidationResult();
-      vr.add('debug', 'Debug event');
-      vr.add('info', 'Info event');
-      vr.add('warn', 'Warn event');
+      vr.addEvent('debug', 'Debug event');
+      vr.addEvent('info', 'Info event');
+      vr.addEvent('warn', 'Warn event');
 
-      expect(vr.success).toBe(true);
+      expect(vr.ok).toBe(true);
     });
 
     it('should return false if any errors occurred', () => {
       const vr = new ValidationResult();
-      vr.add('error', 'Error event');
+      vr.addEvent('error', 'Error event');
 
-      expect(vr.success).toBe(false);
+      expect(vr.ok).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Refined the API for `ValidationResult`:
- added the `error`, `warn`, `info` & `debug` shortcut methods
- added `ok` as an alias for `success` and deprecated the latter
- added `addEvent` as an alias for `add` and deprecated the latter
