### PR TITLE
Export EventLog types; always return new array from toArray

### DIFF
--- a/src/classes/EventLog.ts
+++ b/src/classes/EventLog.ts
@@ -4,14 +4,25 @@ import type { JsonObject } from 'type-fest';
 import { capitalizeFirstWord, isNull, isUndefined, omitUndefined } from 'src/functions';
 import { isDefined } from '../functions/indefinite/isDefined';
 
-interface AddEventOptions {
+export interface AddEventOptions {
   id?: Integer | string;
   data?: JsonObject;
   type?: string;
 }
 
+export interface Event {
+  id?: Integer | string;
+  data?: JsonObject;
+  level: LogLevel;
+  message: string;
+}
+
 export interface EventLogOptions {
   type?: string; // default type to assign to new events
+}
+
+export interface EventMessageOptions {
+  omitLevel?: boolean; // if true, don't prepend the level to the message
 }
 
 export interface FilterEventsParams {
@@ -20,17 +31,6 @@ export interface FilterEventsParams {
 }
 
 export type LogLevel = typeof EventLog.logLevels[number];
-
-export interface EventMessageOptions {
-  omitLevel?: boolean; // if true, don't prepend the level to the message
-}
-
-interface Event {
-  id?: Integer | string;
-  data?: JsonObject;
-  level: LogLevel;
-  message: string;
-}
 
 export class EventLog {
   static readonly logLevels = [

--- a/src/classes/__tests__/EventLog.unit.test.ts
+++ b/src/classes/__tests__/EventLog.unit.test.ts
@@ -34,7 +34,7 @@ describe('EventLog()', () => {
   describe('static merge(:EventLog)', () => {
     it('should return a new EventLog containing all events from the EventLog instances in the array', () => {
       const eventLog1 = new EventLog()
-        .error('First')
+        .error('First', { data: { key: 'sample data' } })
         .warn('Second');
       const eventLog2 = new EventLog()
         .warn('Last');

--- a/src/classes/index.ts
+++ b/src/classes/index.ts
@@ -1,5 +1,6 @@
 export { Directory } from './Directory';
 export type { DirectoryLike } from './Directory';
+export type { AddEventOptions, Event, EventLogOptions, EventMessageOptions, FilterEventsParams } from './EventLog';
 export { EventLog } from './EventLog';
 export type { LogLevel } from './EventLog';
 export { StringCounter } from './StringCounter';

--- a/src/functions/array/__tests__/toArray.unit.test.ts
+++ b/src/functions/array/__tests__/toArray.unit.test.ts
@@ -1,10 +1,11 @@
 import { toArray } from '../toArray';
 
 describe('toArray(value | value[])', () => {
-  it('if the value is an array, should return the value', () => {
+  it('if the value is an array, should return a new array containing the same items', () => {
     const value: unknown[] = [];
     const array = toArray(value);
-    expect(array).toBe(value);
+    expect(array).toStrictEqual(value);
+    expect(array).not.toBe(value);
   });
 
   it('should accept a read-only array', () => {

--- a/src/functions/array/toArray.ts
+++ b/src/functions/array/toArray.ts
@@ -1,5 +1,6 @@
-export function toArray<T>(value: T | ReadonlyArray<T>): T[] {
-  return Array.isArray(value)
-    ? value
-    : [value];
+export function toArray<T>(value: T | ReadonlyArray<T>): Array<T> {
+  if (value instanceof Array) {
+    return [...value];
+  }
+  return [value];
 }


### PR DESCRIPTION
Changed `toArray` so that it always returns a new array: either a copy of the original value (if the value was an array) or the original value as the first item in a new array