### PR TITLE
Refactor: Improve typings of Event data

### DIFF
--- a/src/classes/EventLog.ts
+++ b/src/classes/EventLog.ts
@@ -1,18 +1,19 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import type { Integer } from '@skypilot/common-types';
-import type { JsonObject } from 'type-fest';
 
 import { capitalizeFirstWord, isNull, isUndefined, omitUndefined } from 'src/functions';
 import { isDefined } from '../functions/indefinite/isDefined';
 
-export interface AddEventOptions {
+export interface AddEventOptions<TData = any> {
   id?: Integer | string;
-  data?: JsonObject;
+  data?: TData;
   type?: string;
 }
 
-export interface Event {
+export interface Event<TData = any> {
   id?: Integer | string;
-  data?: JsonObject;
+  data?: TData;
   level: LogLevel;
   message: string;
 }
@@ -121,7 +122,7 @@ export class EventLog {
     return highestLevel === undefined || (EventLog.compareLevels(highestLevel, 'error') < 0);
   }
 
-  addEvent(level: LogLevel, message: string, options: AddEventOptions = {}): Event {
+  addEvent<TData>(level: LogLevel, message: string, options: AddEventOptions<TData> = {}): Event {
     const { id, data, type = this.defaultType } = options;
 
     const event = {
@@ -144,12 +145,12 @@ export class EventLog {
     return this;
   }
 
-  debug(message: string, options: AddEventOptions = {}): EventLog {
+  debug<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
     this.addEvent('debug', message, options);
     return this;
   }
 
-  error(message: string, options: AddEventOptions = {}): EventLog {
+  error<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
     this.addEvent('error', message, options);
     return this;
   }
@@ -173,8 +174,8 @@ export class EventLog {
       .map(event => omitLevel ? event.message : EventLog.formatEventMessage(event));
   }
 
-  getEvents(): Array<Event>;
-  getEvents<L extends LogLevel>(level: L): Array<Event & { level: L }>;
+  getEvents<TData>(): Array<Event<TData>>;
+  getEvents<TData, L extends LogLevel>(level: L): Array<Event<TData> & { level: L }>;
   /* eslint-disable @typescript-eslint/explicit-function-return-type */
   /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
   getEvents(level?: LogLevel | undefined) {
@@ -196,12 +197,12 @@ export class EventLog {
     return (level === undefined ? this.getEvents() : this.getEvents(level)).length > 0;
   }
 
-  info(message: string, options: AddEventOptions = {}): EventLog {
-    this.addEvent('info', message, options);
+  info<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
+    this.addEvent<TData>('info', message, options);
     return this;
   }
 
-  warn(message: string, options: AddEventOptions = {}): EventLog {
+  warn<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
     this.addEvent('warn', message, options);
     return this;
   }

--- a/src/classes/__tests__/EventLog.unit.test.ts
+++ b/src/classes/__tests__/EventLog.unit.test.ts
@@ -199,9 +199,19 @@ describe('EventLog()', () => {
 
   describe('getEvents()', () => {
     it('should return all events', () => {
+      interface Data { key: string }
+      expect.assertions(2);
+
       const eventLog = new EventLog();
-      eventLog.info( 'Info event');
+      eventLog.info<Data>( 'Info event', { data: { key: 'typed value' } });
       eventLog.debug('Debug event');
+
+
+      const [firstEvent] = eventLog.getEvents<Data>();
+      if (firstEvent) {
+        const { key } = firstEvent.data || {};
+        expect(key).toBe('typed value');
+      }
 
       expect(eventLog.getEvents()).toHaveLength(2);
     });


### PR DESCRIPTION
- Replaced the `JsonObject` type of of the `Event.data` property with an optional type parameter
- Loosened the assumed type of `Event.data` to "any"
- Added type parameters to `EventLog` class methods