### PR TITLE
Fix: writeDataFile ignores dateTimeFormat preset

### DIFF
--- a/src/functions/filesystem/writeDataFile.ts
+++ b/src/functions/filesystem/writeDataFile.ts
@@ -77,8 +77,8 @@ export async function writeDataFile<T>(
     fileNameElements.push(identifier);
   }
   if (dateTimeFormat) {
-    const dateTimeOptions = typeof dateTimeFormat === 'string'
-      ? { dateTime: isoDateTime, presetCode: dateTimeFormat }
+    const dateTimeOptions: DateTimeStampOptions = typeof dateTimeFormat === 'string'
+      ? { dateTime: isoDateTime, preset: dateTimeFormat }
       : { dateTime: isoDateTime, ...dateTimeFormat };
     fileNameElements.push(makeDateTimeStamp(dateTimeOptions));
   }


### PR DESCRIPTION
Fixed an issue where a preset code used as a `dateTimeFormat` option in `writeDataFile` was ignored; the default ISO format was used instead
