### PR TITLE
Feature: Can return indices of first & last items defined by a slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ carry the overhead of checking argument types or handling type coercion.
 -   `pushIf`
 -   `range(start: Integer, end: Integer): Integer[]`
 -   `shuffle`
+-   `sliceToIndices(startAt: Integer | undefined, stopBefore: Integer | undefined): [Integer, Integer]`
 -   `toArray<T>(T | T[]): T[]`
 -   `toUniqueArray`
 

--- a/src/__tests__/verify-exports.app.test.ts
+++ b/src/__tests__/verify-exports.app.test.ts
@@ -16,6 +16,7 @@ const intendedExports: string[] = [
   'pushIf',
   'range',
   'shuffle',
+  'sliceToIndices',
   'toArray',
   'toUniqueArray',
 

--- a/src/functions/array/__tests__/sliceToIndices.unit.test.ts
+++ b/src/functions/array/__tests__/sliceToIndices.unit.test.ts
@@ -1,0 +1,118 @@
+import { sliceToIndices } from '../sliceToIndices';
+
+describe('sliceToIndices()', () => {
+  it('should compute start and stop indices based on startAt & stopBefore', () => {
+    const items = [1, 2, 3];
+    {
+      const [startAt, stopBefore] = [0, 3];
+      const expected = [0, 2];
+
+      const actual = sliceToIndices(items, startAt, stopBefore);
+      expect(actual).toStrictEqual(expected);
+    }
+    {
+      const [startAt, stopBefore] = [2, 3];
+      const expected = [2, 2];
+
+      const actual = sliceToIndices(items, startAt, stopBefore);
+      expect(actual).toStrictEqual(expected);
+    }
+  });
+
+  it('should constrain startIndex to no less than zero', () => {
+    const items = [1, 2, 3];
+    const [startAt, stopBefore] = [-4, 3];
+    const expected = [0, 2];
+
+    const actual = sliceToIndices(items, startAt, stopBefore);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('should constrain stopIndex to the index of the last item', () => {
+    const items = [1, 2, 3];
+    const [startAt, stopBefore] = [1, 4];
+    const expected = [1, 2];
+
+    const actual = sliceToIndices(items, startAt, stopBefore);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('startIndex should never be less than the index of the first item', () => {
+    const items = [1, 2, 3];
+    {
+      const [startAt, stopBefore] = [-5, 2];
+      const expected = [0, 1];
+
+      const actual = sliceToIndices(items, startAt, stopBefore);
+      expect(actual).toStrictEqual(expected);
+    }
+  });
+
+  it('stopIndex should never be greater than the index of the last item', () => {
+    const items = [1, 2, 3];
+    const [startAt, stopBefore] = [0, 5];
+    const expected = [0, 2];
+
+    const actual = sliceToIndices(items, startAt, stopBefore);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('given undefined startAt, should return a startIndex of 0', () => {
+    const items = [1, 2, 3];
+    const [startAt, stopBefore] = [undefined, 3];
+    const expected = [0, 2];
+
+    const actual = sliceToIndices(items, startAt, stopBefore);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('given undefined stopBefore, should set it to the index of the last item', () => {
+    const items = [1, 2, 3];
+    const [startAt, stopBefore] = [1, undefined];
+    const expected = [1, 2];
+
+    const actual = sliceToIndices(items, startAt, stopBefore);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('given undefined startAt & stopBefore, should set them to [0, array length - 1] (the entire array)', () => {
+    const items = [1, 2, 3];
+    const [startAt, stopBefore] = [undefined, undefined];
+    const expected = [0, 2];
+
+    const actual = sliceToIndices(items, startAt, stopBefore);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('should constrain negative values to the size of the array', () => {
+    const items = [1, 2, 3];
+    {
+      const [startAt, stopBefore] = [-5, -1];
+      const expected = [0, 1];
+
+      const actual = sliceToIndices(items, startAt, stopBefore);
+      expect(actual).toStrictEqual(expected);
+    }
+    {
+      const [startAt, stopBefore] = [2, -5];
+      const expected = [-1, -1];
+
+      const actual = sliceToIndices(items, startAt, stopBefore);
+      expect(actual).toStrictEqual(expected);
+    }
+  });
+
+  it('given an empty array, should always return [0, 0]', () => {
+    const items: number[] = [];
+    const expected = [-1, -1];
+
+    const startAtValues = [-1, undefined, 0, 1];
+    const stopBeforeValues = [-1, undefined, 0, 1];
+    for (const startAt of startAtValues) {
+      for (const stopBefore of stopBeforeValues) {
+        const actual = sliceToIndices(items, startAt, stopBefore);
+        expect(actual).toStrictEqual(expected);
+      }
+    }
+  });
+});

--- a/src/functions/array/index.ts
+++ b/src/functions/array/index.ts
@@ -12,6 +12,7 @@ export { pickRandomItems } from './pickRandomItems';
 export { pushIf } from './pushIf';
 export { shuffle } from './shuffle';
 export { Slice } from './Slice';
+export { sliceToIndices } from './sliceToIndices';
 export { range } from './range';
 export { sorterOnDigits } from './sorters/sorterOnDigits';
 export { toArray } from './toArray';

--- a/src/functions/array/sliceToIndices.ts
+++ b/src/functions/array/sliceToIndices.ts
@@ -1,0 +1,25 @@
+import type { Integer } from '@skypilot/common-types';
+
+import { isUndefined } from 'src/functions/indefinite/isUndefined';
+
+/**
+ * @description Return the indices of the first & last items of the array range defined by the slice
+ */
+export function sliceToIndices<T>(
+  items: T[], startAt: Integer | undefined, stopBefore: Integer | undefined
+): [Integer, Integer] {
+  const definiteStartAt = isUndefined(startAt) ? 0 : startAt;
+  const definiteStopBefore = isUndefined(stopBefore) ? items.length : stopBefore;
+
+  const indexOfFirstItem = definiteStartAt >= 0
+    ? Math.min(definiteStartAt, items.length - 1)
+    : Math.max(0, items.length + definiteStartAt);
+
+  const indexOfLastItem = definiteStopBefore >= 0
+    ? Math.min(definiteStopBefore - 1, items.length - 1)
+    : Math.max(-1, items.length + definiteStopBefore - 1);
+
+  return indexOfLastItem < indexOfFirstItem
+    ? [-1, -1]
+    : [indexOfFirstItem, indexOfLastItem];
+}


### PR DESCRIPTION
Added the `sliceToIndices` function, which returns the indices of the first & last items in an array that fall into the range defined by a slice
