### PR TITLE
Fix: sliceToIndices returns wrong values when startAt >= array length

### DIFF
--- a/src/functions/array/__tests__/sliceToIndices.unit.test.ts
+++ b/src/functions/array/__tests__/sliceToIndices.unit.test.ts
@@ -104,6 +104,24 @@ describe('sliceToIndices()', () => {
     }
   });
 
+  it('if startAt references an index higher than the index of the last item, should return [-1, -1]', () => {
+    const items = [1, 2, 3];
+    const [startAt, stopBefore] = [3, 4];
+    const expected = [-1, -1];
+
+    const actual = sliceToIndices(items, startAt, stopBefore);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('if startAt references an index >= stopBefore, should return [-1, -1]', () => {
+    const items = [1, 2, 3];
+    const [startAt, stopBefore] = [2, -3];
+    const expected = [-1, -1];
+
+    const actual = sliceToIndices(items, startAt, stopBefore);
+    expect(actual).toStrictEqual(expected);
+  });
+
   it('given an empty array, should always return [-1, -1]', () => {
     const items: number[] = [];
     const expected = [-1, -1];

--- a/src/functions/array/sliceToIndices.ts
+++ b/src/functions/array/sliceToIndices.ts
@@ -18,6 +18,10 @@ export function sliceToIndices<T>(
   const definiteStartAt = isUndefined(startAt) ? 0 : startAt;
   const definiteStopBefore = isUndefined(stopBefore) ? arrayLength: stopBefore;
 
+  if (definiteStartAt >= arrayLength) {
+    return [-1, -1];
+  }
+
   const indexOfFirstItem = definiteStartAt >= 0
     ? Math.min(definiteStartAt, arrayLength - 1)
     : Math.max(0, arrayLength + definiteStartAt);


### PR DESCRIPTION
Fixed an issue where `sliceToIndices` treated a value greater than or equal to the array length as a reference to the end of the array. The function now correctly determines that this results in an empty array.
