### PR TITLE
Feature: Can control indentation of error messages

### DIFF
--- a/src/classes/EventLog.ts
+++ b/src/classes/EventLog.ts
@@ -53,6 +53,7 @@ export class EventLog {
 
   defaultType?: string;
   echoOptions: EchoOptions;
+  indentLevel: Integer | undefined = undefined;
 
   private _events: Event[] = [];
 
@@ -145,7 +146,7 @@ export class EventLog {
   }
 
   addEvent<TData>(level: LogLevel, message: string, options: AddEventOptions<TData> = {}): Event {
-    const { id, data, indentLevel, type = this.defaultType } = options;
+    const { id, data, indentLevel = this.indentLevel, type = this.defaultType } = options;
 
     const event = {
       ...mergeIf(isDefined(indentLevel), { indentLevel }),

--- a/src/classes/__tests__/EventLog.unit.test.ts
+++ b/src/classes/__tests__/EventLog.unit.test.ts
@@ -125,6 +125,40 @@ describe('EventLog()', () => {
       expect(actualEvents).toHaveLength(1);
       expect(actualEvents[0]).toMatchObject(expectedEvent);
     });
+
+    it('if indentLevel is not set, should not add it to the event', () => {
+      const eventLog = new EventLog();
+      eventLog.addEvent('info', 'no indentLevel');
+      const expectedEvent = {
+        level: 'info',
+        message: 'no indentLevel',
+      };
+
+      const actualEvents = eventLog.getEvents();
+      expect(actualEvents).toHaveLength(1);
+      expect(actualEvents[0]).toStrictEqual(expectedEvent);
+    });
+
+    it('if indentLevel is set, should add it to the event', () => {
+      const eventLog = new EventLog();
+      eventLog.addEvent('info', 'has indentLevel', { indentLevel: 0 });
+      eventLog.error('has indentLevel', { indentLevel: 1 });
+      const expectedEvents = [
+        {
+          indentLevel: 0,
+          level: 'info',
+          message: 'has indentLevel',
+        },
+        {
+          indentLevel: 1,
+          level: 'error',
+          message: 'has indentLevel',
+        },
+      ];
+
+      const actualEvents = eventLog.getEvents();
+      expect(actualEvents).toStrictEqual(expectedEvents);
+    });
   });
 
   describe('append(...eventLogs: EventLog[])', () => {

--- a/src/classes/__tests__/EventLog.unit.test.ts
+++ b/src/classes/__tests__/EventLog.unit.test.ts
@@ -126,6 +126,27 @@ describe('EventLog()', () => {
       expect(actualEvents[0]).toMatchObject(expectedEvent);
     });
 
+    it('indentLevel for an event should default to the value set on the EventLog instance', () => {
+      const eventLog = new EventLog();
+      eventLog.addEvent('info', 'no indentLevel');
+      eventLog.indentLevel = 1;
+      eventLog.warn('has indentLevel');
+      const expectedEvents = [
+        {
+          level: 'info',
+          message: 'no indentLevel',
+        },
+        {
+          indentLevel: 1,
+          level: 'warn',
+          message: 'has indentLevel',
+        },
+      ];
+
+      const actualEvents = eventLog.getEvents();
+      expect(actualEvents).toStrictEqual(expectedEvents);
+    });
+
     it('if indentLevel is not set, should not add it to the event', () => {
       const eventLog = new EventLog();
       eventLog.addEvent('info', 'no indentLevel');


### PR DESCRIPTION
Added an `indentLevel` option to the `EventLog.addEvent` API
