### PR TITLE
Fix: omit* functions disallow valid values

### DIFF
--- a/src/functions/object/__tests__/omitUndefined.unit.test.ts
+++ b/src/functions/object/__tests__/omitUndefined.unit.test.ts
@@ -12,7 +12,7 @@ describe('omitUndefined(:object)', () => {
   });
 
   it('given an object with all values defined, should return an equal but not identical object', () => {
-    const originalObj = { a: 1, b: 2 };
+    const originalObj = { a: 1, b: () => true };
 
     const noUndefined = omitUndefined(originalObj);
 

--- a/src/functions/object/omitByValue.ts
+++ b/src/functions/object/omitByValue.ts
@@ -1,11 +1,9 @@
 // TODO: Optionally, recursively omit nested entries having the value
 
-import { JsonObject } from 'type-fest';
-
 /**
  * @description Remove keys whose values have the given value and return as a new object
  */
-export function omitByValue<T extends JsonObject, V>(
+export function omitByValue<T extends { [key: string]: any }, V>(
   value: V, obj: T
 ): Partial<T> {
   return Object.entries(obj).reduce((compactedObj, entry) => {

--- a/src/functions/object/omitEmpty.ts
+++ b/src/functions/object/omitEmpty.ts
@@ -1,11 +1,11 @@
 import type { EmptyObject } from '@skypilot/common-types';
-import type { ConditionalExcept, JsonObject } from 'type-fest';
+import type { ConditionalExcept } from 'type-fest';
 
 /**
  * @description Return a copy of the object, but omit any entries whose values are empty objects
  * or empty arrays
  */
-export function omitEmpty<O extends JsonObject>(obj: O): ConditionalExcept<O, EmptyObject | []> {
+export function omitEmpty<O extends { [key: string]: any }>(obj: O): ConditionalExcept<O, EmptyObject | []> {
   return Object.entries(obj).reduce((accObj, [key, value]) => {
     if (
       value instanceof Object

--- a/src/functions/object/omitEmptyArrays.ts
+++ b/src/functions/object/omitEmptyArrays.ts
@@ -1,10 +1,10 @@
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-import type { ConditionalExcept, JsonObject } from 'type-fest';
+import type { ConditionalExcept } from 'type-fest';
 
 // TODO: Make this function optionally recursive
 
 /* Given an object, return a new object without any entries whose values are empty arrays */
-export function omitEmptyArrays<O extends JsonObject>(obj: O): ConditionalExcept<O, []> {
+export function omitEmptyArrays<O extends { [key: string]: any }>(obj: O): ConditionalExcept<O, []> {
   return Object.entries(obj).reduce((accObj, [key, value]) => {
     if (Array.isArray(value) && !value.length) {
       return accObj;

--- a/src/functions/object/omitEmptyObjects.ts
+++ b/src/functions/object/omitEmptyObjects.ts
@@ -1,12 +1,12 @@
 import type { EmptyObject } from '@skypilot/common-types';
-import type { ConditionalExcept, JsonObject } from 'type-fest';
+import type { ConditionalExcept } from 'type-fest';
 
 // TODO: Make this function optionally recursive
 
 /**
  * @description Return a copy of the object, but omit any entries whose values are empty arrays
  */
-export function omitEmptyObjects<O extends JsonObject>(obj: O): ConditionalExcept<O, EmptyObject> {
+export function omitEmptyObjects<O extends { [key: string]: any }>(obj: O): ConditionalExcept<O, EmptyObject> {
   return Object.entries(obj).reduce((accObj, [key, value]) => {
     if (
       value instanceof Object

--- a/src/functions/object/omitFalsy.ts
+++ b/src/functions/object/omitFalsy.ts
@@ -4,14 +4,14 @@
  */
 
 import { Falsy } from '@skypilot/common-types';
-import { ConditionalExcept, JsonObject } from 'type-fest';
+import { ConditionalExcept } from 'type-fest';
 
 type NoFalsy<T> = ConditionalExcept<T, Falsy>
 
 /**
  * @description Remove keys whose values are falsy and return as a new object
  */
-export function omitFalsy<T extends JsonObject>(obj: T): NoFalsy<T> {
+export function omitFalsy<T extends { [key: string]: any }>(obj: T): NoFalsy<T> {
   return Object.entries(obj).reduce((compactedObj, entry) => {
     const [key, value] = entry;
     if (!value) {

--- a/src/functions/object/omitUndefined.ts
+++ b/src/functions/object/omitUndefined.ts
@@ -3,14 +3,14 @@
   TODO: Optionally, recursively omit nested entries with undefined values.
  */
 
-import { ConditionalExcept, JsonObject } from 'type-fest';
+import { ConditionalExcept } from 'type-fest';
 
 import { isUndefined } from '../indefinite';
 
 /**
  * @description Remove keys whose values have the given value and return as a new object
  */
-export function omitUndefined<O extends JsonObject>(obj: O): ConditionalExcept<O, undefined> {
+export function omitUndefined<O extends { [key: string]: any }>(obj: O): ConditionalExcept<O, undefined> {
   return Object.entries(obj).reduce((acc, entry) => {
     const [key, value] = entry;
     if (isUndefined(value) ) {


### PR DESCRIPTION
The various `omit*` functions required the object to be serializable, which is not always the use case for these functions. Fixed by allowing `any` object values
