### PR TITLE
Feature: Improve EventLog API & formatting

### DIFF
--- a/src/classes/EventLog.ts
+++ b/src/classes/EventLog.ts
@@ -13,11 +13,9 @@ export interface AddEventOptions<TData = any> {
   type?: string;
 }
 
-export interface EchoOptions {
-  event?: boolean;
-  message?: boolean;
-  minLevel?: LogLevel;
-}
+export type EchoLevel = LogLevel | 'off';
+
+export type EchoDetail = 'message' | 'event';
 
 export interface Event<TData = any> {
   id?: Integer | string;
@@ -28,8 +26,10 @@ export interface Event<TData = any> {
 }
 
 export interface EventLogOptions {
-  echo?: EchoOptions;
+  echoDetail?: EchoDetail;
+  echoLevel?: EchoLevel;
   baseIndentLevel?: Integer;
+  logLevel?: LogLevel;
   type?: string; // default type to assign to new events
 }
 
@@ -54,17 +54,18 @@ export class EventLog {
 
   baseIndentLevel: Integer;
   defaultType?: string;
-  echoOptions: EchoOptions;
+  echoDetail: 'message' | 'event';
+  echoLevel: LogLevel | 'off';
   indentLevel: Integer | undefined = undefined;
 
   private _events: Event[] = [];
 
   constructor(options: EventLogOptions = {}) {
-    const { baseIndentLevel = 0, echo = {}, type } = options;
-    const { event = false, message = false, minLevel = 'error' } = echo;
+    const { baseIndentLevel = 0, echoLevel = 'off', echoDetail = 'message', type } = options;
 
     this.baseIndentLevel = baseIndentLevel;
-    this.echoOptions = { event, message, minLevel };
+    this.echoDetail = echoDetail;
+    this.echoLevel = echoLevel;
 
     if (isDefined(type)) {
       this.defaultType = type;
@@ -181,12 +182,11 @@ export class EventLog {
     };
     this._events.push(event);
 
-    if (EventLog.compareLevels(level, this.echoOptions.minLevel) >= 0) {
-      if (this.echoOptions.message) {
-        console[level](EventLog.formatEventMessage(event));
-      }
-      if (this.echoOptions.event) {
+    if (this.echoLevel !== 'off' && EventLog.compareLevels(level, this.echoLevel) >= 0) {
+      if (this.echoDetail === 'event') {
         console[level](EventLog.formatEvent(event)); // TODO: Improve formatting; also allow a custom formatter
+      } else {
+        console[level](EventLog.formatEventMessage(event));
       }
     }
 

--- a/src/classes/EventLog.ts
+++ b/src/classes/EventLog.ts
@@ -108,6 +108,24 @@ export class EventLog {
     return `${capitalizeFirstWord(event.level)}: ${event.message}`;
   }
 
+  private static formatEvent(event: Event): string {
+    function formatEntry(key: string, value: any): string {
+      if (isUndefined(value)) {
+        return '';
+      }
+      return EventLog.indent(`${key}: ${JSON.stringify(value)}`, (event.indentLevel || 0) + 1);
+    }
+    return [
+      EventLog.indent(this.formatEventMessage(event), event.indentLevel),
+      formatEntry('id', event.id),
+      formatEntry('data', event.data),
+    ].filter(Boolean).join('\n');
+  }
+
+  private static indent(text: string, indentLevel: Integer | undefined = 0): string {
+    return ['  '.repeat(indentLevel || 0), text].join('');
+  }
+
   get count(): Integer {
     return this._events.length;
   }
@@ -163,16 +181,12 @@ export class EventLog {
     };
     this._events.push(event);
 
-    function indent(text: string, indentLevel: Integer | undefined = 0): string {
-      return ['  '.repeat(indentLevel || 0), text].join('');
-    }
     if (EventLog.compareLevels(level, this.echoOptions.minLevel) >= 0) {
-      const indentedMessage = indent(message, indentLevel);
       if (this.echoOptions.message) {
-        console[level](indentedMessage);
+        console[level](EventLog.formatEventMessage(event));
       }
       if (this.echoOptions.event) {
-        console[level](indentedMessage);
+        console[level](EventLog.formatEvent(event)); // TODO: Improve formatting; also allow a custom formatter
       }
     }
 

--- a/src/classes/__tests__/EventLog.unit.test.ts
+++ b/src/classes/__tests__/EventLog.unit.test.ts
@@ -33,13 +33,13 @@ describe('EventLog()', () => {
 
   describe('static merge(:EventLog)', () => {
     it('should return a new EventLog containing all events from the EventLog instances in the array', () => {
-      const eventLog1 = new EventLog()
-        .error('First', { data: { key: 'sample data' } })
+      const eventLog1 = new EventLog({ echoLevel: 'debug', echoDetail: 'event' })
+        .info('First', { id: 'any', data: { key: 'sample data', array: [1, 2], nested: { a: 1, b: 2 } } })
         .warn('Second');
       const eventLog2 = new EventLog()
         .warn('Last');
       const expectedMessages = [
-        'Error: First',
+        'Info: First',
         'Warn: Second',
         'Warn: Last',
       ];
@@ -47,9 +47,6 @@ describe('EventLog()', () => {
       const mergedEventLog = EventLog.merge([eventLog1, eventLog2]);
       expect(mergedEventLog.getMessages()).toStrictEqual(expectedMessages);
     });
-  });
-
-  describe('constructor()', () => {
   });
 
   describe('get events.error', () => {

--- a/src/classes/index.ts
+++ b/src/classes/index.ts
@@ -1,6 +1,14 @@
 export { Directory } from './Directory';
 export type { DirectoryLike } from './Directory';
-export type { AddEventOptions, Event, EventLogOptions, EventMessageOptions, FilterEventsParams } from './EventLog';
+export type {
+  AddEventOptions,
+  EchoDetail,
+  EchoLevel,
+  Event,
+  EventLogOptions,
+  EventMessageOptions,
+  FilterEventsParams,
+} from './EventLog';
 export { EventLog } from './EventLog';
 export type { LogLevel } from './EventLog';
 export { StringCounter } from './StringCounter';

--- a/src/functions/object/__tests__/isPlainObject.type.test.ts
+++ b/src/functions/object/__tests__/isPlainObject.type.test.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+// Uncomment the text line to enable typechecking
+// @ts-nocheck
+
+import { PlainObject } from '../isPlainObject';
+
+function takesPlainObject(_plainObject: PlainObject): void {
+  /* do nothing */
+}
+
+describe('PlainObject', () => {
+  it('should accept any object that is not an array, function, or class instance', () => {
+    type MyObj = {
+      a: string;
+    }
+    const typedObj: MyObj = { a: 'value' };
+
+    takesPlainObject({});
+    takesPlainObject({ a: 1 });
+    takesPlainObject(typedObj);
+    takesPlainObject(new Object());
+  });
+
+  it('should reject any primitive value', () => {
+    takesPlainObject(true);
+    takesPlainObject(0);
+    takesPlainObject('');
+  });
+
+  it('should reject a function', () => {
+    const fn = (): void => void 0;
+    takesPlainObject(fn);
+  });
+
+  it('should reject any array', () => {
+    takesPlainObject([]);
+    takesPlainObject([1]);
+  });
+
+  it('should reject any instance of a class other than Object', () => {
+    class MyClass {
+      constructor(public prop?: unknown) {}
+    }
+
+    takesPlainObject(MyClass);
+    takesPlainObject(new Date());
+    takesPlainObject(new Map());
+    takesPlainObject(new MyClass());
+    takesPlainObject(new Set());
+    takesPlainObject(new WeakMap());
+  });
+});

--- a/src/functions/object/__tests__/isPlainObject.unit.test.ts
+++ b/src/functions/object/__tests__/isPlainObject.unit.test.ts
@@ -1,0 +1,43 @@
+import { isPlainObject } from '../isPlainObject';
+
+describe('isPlainObject(value: any)', () => {
+  it('should return false if the value is any primitive', () => {
+    const primitives = [true, false, 0, 1, '', 'non-empty-string'];
+    for (const primitive of primitives) {
+      expect(isPlainObject(primitive)).toBe(false);
+    }
+  });
+
+  it('should return false if the value is a function', () => {
+    const fn = (): void => void 0;
+    expect(isPlainObject(fn)).toBe(false);
+  });
+
+  it('should return false if the value is an array', () => {
+    expect(isPlainObject([])).toBe(false);
+  });
+
+  it('should return false for an instance of any class other than Object', () => {
+    class MyClass {
+      constructor(public prop?: unknown) {}
+    }
+
+    const instances = [
+      new Date(),
+      new Map(),
+      new MyClass(),
+      new Set(),
+      new WeakMap(),
+    ];
+    for (const instance of instances) {
+      expect(isPlainObject(instance)).toBe(false);
+    }
+  });
+
+  it('should return true for any other object', () => {
+    const plainObjects = [{}, { a: 1 }, new Object()];
+    for (const plainObject of plainObjects) {
+      expect(isPlainObject(plainObject)).toBe(true);
+    }
+  });
+});

--- a/src/functions/object/isPlainObject.ts
+++ b/src/functions/object/isPlainObject.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type PlainObject = { [key: string]: unknown } & ({ bind?: never } | { call?: never });
+
+export function isPlainObject(value: PlainObject | unknown): value is PlainObject {
+  return value instanceof Object && Object.getPrototypeOf(value) === Object.prototype;
+}


### PR DESCRIPTION
**BREAKING CHANGES:**

- The `echoOptions` object previously accepted by the `EventLog` constructor has been replaced by two props: `echoLevel` and `echoDetail`

**Features:**

- `EventLog` events can now be formatted when echoed to the console

**Tools:**

- `isPlainObject` checks whether an object is a "plain object" (an object that is not an array, function, or `null`).