### PR TITLE
feat: Respect echo options when appending events

### DIFF
--- a/src/classes/EventLog.ts
+++ b/src/classes/EventLog.ts
@@ -3,7 +3,7 @@
 
 import type { Integer } from '@skypilot/common-types';
 
-import { capitalizeFirstWord, isNull, isUndefined, mergeIf, omitUndefined } from 'src/functions';
+import { capitalizeFirstWord, isUndefined, mergeIf, omitUndefined } from 'src/functions';
 import { isDefined } from '../functions/indefinite/isDefined';
 import { isPlainObject } from '../functions/object/isPlainObject';
 
@@ -74,36 +74,11 @@ export class EventLog {
     }
   }
 
-  // Return a positive number if a > b; a negative number if a < b, or a 0 if they are equal. Higher = more severe
-  static compareLevels(a: EchoLevel | null | undefined, b: EchoLevel | null | undefined): Integer {
-    if (a === b) {
-      return 0;
+  static meetsThreshold(logLevel: LogLevel | undefined, threshold: EchoLevel | undefined): boolean {
+    if (isUndefined(logLevel) || isUndefined(threshold) || threshold === 'off') {
+      return false;
     }
-
-    function resolve(echoLevel: EchoLevel | null | undefined): EchoLevel {
-      if (isNull(echoLevel)) {
-        return 'error';
-      }
-      if (isUndefined(echoLevel)) {
-        return 'off';
-      }
-      return echoLevel;
-    }
-
-    const resolvedA = resolve(a);
-    const resolvedB = resolve(b);
-
-    if (resolvedA === 'off') {
-      return -1;
-    } else if (resolvedB === 'off') {
-      return 1;
-    }
-
-    return EventLog.logLevels.indexOf(resolvedA) - EventLog.logLevels.indexOf(resolvedB);
-  }
-
-  static meetsThreshold(echoLevel: EchoLevel | null | undefined, threshold: EchoLevel | null | undefined): boolean {
-    return this.compareLevels(echoLevel, threshold) >= 0;
+    return this.compareLevels(logLevel, threshold) >= 0;
   }
 
   /**
@@ -115,6 +90,19 @@ export class EventLog {
       mergedEventLog.addEvents(eventLog.getEvents());
     });
     return mergedEventLog;
+  }
+
+  // Return a positive number if a > b; a negative number if a < b, or a 0 if they are equal. Higher = more severe
+  private static compareLevels(a: LogLevel, b: LogLevel): Integer {
+    if (isUndefined(a)) {
+      return -1;
+    }
+
+    if (a === b) {
+      return 0;
+    }
+
+    return EventLog.logLevels.indexOf(a) - EventLog.logLevels.indexOf(b);
   }
 
   private static formatEventMessage(event: Event): string {

--- a/src/classes/__tests__/EventLog.unit.test.ts
+++ b/src/classes/__tests__/EventLog.unit.test.ts
@@ -1,33 +1,34 @@
 import { EventLog } from '../EventLog';
 
 describe('EventLog()', () => {
-  describe('static compareLevels(a: LogLevel | null, b: logLevel | null)', () => {
-    it('should return a negative number if level a < level b', () => {
-      const comparison = EventLog.compareLevels('warn', 'error');
-      expect(comparison).toBeLessThan(0);
+  describe('static meetsThreshold(a: LogLevel | undefined, b: EchoLevel | undefined)', () => {
+    it('should return false if level a < level b', () => {
+      expect(
+        EventLog.meetsThreshold('warn', 'error')
+      ).toBe(false);
     });
 
-    it('should return a positive number if level a > level b', () => {
-      const comparison = EventLog.compareLevels('info', 'debug');
-      expect(comparison).toBeGreaterThan(0);
+    it('should return true if level a >= level b', () => {
+      expect(
+        EventLog.meetsThreshold('info', 'debug')
+      ).toBe(true);
     });
 
-    it("should treat a null value as 'error'", () => {
+    it("no value should meet the threshold of 'off'", () => {
       expect(
-        EventLog.compareLevels('error', null)
-      ).toBe(0);
-      expect(
-        EventLog.compareLevels(null, 'error')
-      ).toBe(0);
+        EventLog.meetsThreshold('error', undefined)
+      ).toBe(false);
     });
 
-    it("should treat undefined as 'off'", () => {
+    it('an undefined logLevel should never meet a threshold', () => {
       expect(
-        EventLog.compareLevels('debug', undefined)
-      ).toBeGreaterThan(0);
+        // Doesn't meet the lowest threshold
+        EventLog.meetsThreshold(undefined, 'debug')
+      ).toBe(false);
       expect(
-        EventLog.compareLevels(undefined, 'debug')
-      ).toBeLessThan(0);
+        // Doesn't meet the threshold of 'off'
+        EventLog.meetsThreshold(undefined, 'off')
+      ).toBe(false);
     });
   });
 

--- a/src/classes/__tests__/EventLog.unit.test.ts
+++ b/src/classes/__tests__/EventLog.unit.test.ts
@@ -12,16 +12,16 @@ describe('EventLog()', () => {
       expect(comparison).toBeGreaterThan(0);
     });
 
-    it('should treat a null value as higher than any log level', () => {
+    it("should treat a null value as 'error'", () => {
       expect(
         EventLog.compareLevels('error', null)
-      ).toBeLessThan(0);
+      ).toBe(0);
       expect(
         EventLog.compareLevels(null, 'error')
-      ).toBeGreaterThan(0);
+      ).toBe(0);
     });
 
-    it('should treat undefined as lower than any log level', () => {
+    it("should treat undefined as 'off'", () => {
       expect(
         EventLog.compareLevels('debug', undefined)
       ).toBeGreaterThan(0);
@@ -209,7 +209,7 @@ describe('EventLog()', () => {
 
   describe('append(...eventLogs: EventLog[])', () => {
     it('should return a new EventLog containing all events from the EventLog arguments', () => {
-      const addendumLog = new EventLog()
+      const addendumLog = new EventLog({ echoLevel: 'error' })
         .error('Second')
         .warn('Third');
       const expectedMessages = [
@@ -219,7 +219,7 @@ describe('EventLog()', () => {
         'Error: Last',
       ];
 
-      const baseLog = new EventLog()
+      const baseLog = new EventLog({ echoLevel: 'warn' })
         .warn('First')
         .append(addendumLog)
         .error('Last');


### PR DESCRIPTION
`EventLog.append` now respects the `echoLevel` and `echoDetail` options when appending events
