### PR TITLE
Feature: Can get the number of events of any type in EventLog

### DIFF
--- a/src/classes/EventLog.ts
+++ b/src/classes/EventLog.ts
@@ -137,8 +137,13 @@ export class EventLog {
     return ['  '.repeat(indentLevel || 0), text].join('');
   }
 
-  get count(): Integer {
-    return this._events.length;
+  get counts(): Record<LogLevel, Integer> {
+    return {
+      debug: this.count('debug'),
+      info: this.count('info'),
+      warn: this.count('warn'),
+      error: this.count('error'),
+    };
   }
 
   get events(): Record<LogLevel, Event[]> {
@@ -221,6 +226,13 @@ export class EventLog {
     return this;
   }
 
+  count(logLevel?: LogLevel): Integer {
+    return (
+      isUndefined(logLevel) ? this._events : this.getEvents(logLevel)
+    ).length;
+  }
+
+
   debug<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {
     this.addEvent('debug', message, options);
     return this;
@@ -267,10 +279,8 @@ export class EventLog {
       .map(event => omitLevel ? event.message : EventLog.formatEventMessage(event));
   }
 
-  has(): boolean;
-  has(level: LogLevel): boolean;
-  has(level?: LogLevel): boolean {
-    return (level === undefined ? this.getEvents() : this.getEvents(level)).length > 0;
+  has(level?: LogLevel | undefined): boolean {
+    return this.count(level) > 0;
   }
 
   info<TData>(message: string, options: AddEventOptions<TData> = {}): EventLog {

--- a/src/classes/__tests__/EventLog.unit.test.ts
+++ b/src/classes/__tests__/EventLog.unit.test.ts
@@ -90,12 +90,12 @@ describe('EventLog()', () => {
   describe('addEvent()', () => {
     it('should add the event to the EventLog', () => {
       const eventLog = new EventLog();
-      expect(eventLog.count).toBe(0);
+      expect(eventLog.count()).toBe(0);
       expect(eventLog.hasEvents).toBe(false);
 
       eventLog.addEvent('error', 'An error occurred');
 
-      expect(eventLog.count).toBe(1);
+      expect(eventLog.count()).toBe(1);
       expect(eventLog.hasEvents).toBe(true);
       expect(eventLog.events.error).toHaveLength(1);
       expect(eventLog.events.error[0]).toMatchObject({
@@ -230,6 +230,40 @@ describe('EventLog()', () => {
     });
   });
 
+  describe('count(?:LogLevel)', () => {
+    it('should return the number of events in the log', () => {
+      const eventLog = new EventLog()
+        .info('info 1')
+        .debug('debug')
+        .info('info 2')
+        .warn('warn');
+      expect(eventLog.count()).toBe(4);
+      expect(eventLog.count('debug')).toBe(1);
+      expect(eventLog.count('info')).toBe(2);
+      expect(eventLog.count('warn')).toBe(1);
+      expect(eventLog.count('error')).toBe(0);
+    });
+  });
+
+  describe('get counts', () => {
+    it('should return an object containing counts for each log level', () => {
+      const eventLog = new EventLog()
+        .info('info 1')
+        .debug('debug')
+        .info('info 2')
+        .warn('warn');
+      const expected = {
+        debug: 1,
+        info: 2,
+        warn: 1,
+        error: 0,
+      };
+
+      const actual = eventLog.counts;
+      expect(actual).toStrictEqual(expected);
+    });
+  });
+
   describe('debug(), error(), info() & warn()', () => {
     it('should be a shorthand for addEvent() but return the instance to allow chaining', () => {
       const eventLog = new EventLog()
@@ -246,7 +280,7 @@ describe('EventLog()', () => {
 
       const actualMessages = eventLog.getMessages();
       expect(actualMessages).toStrictEqual(expectedMessages);
-      expect(eventLog.count).toBe(4);
+      expect(eventLog.count()).toBe(4);
       expect(eventLog.hasEvents).toBe(true);
     });
   });


### PR DESCRIPTION
**BREAKING CHANGES:**

- The `EventLog.count` number accessor has been replaced by the `EventLog.count()` method and the `EventLog.counts` object accessor

**Features:**

- `EventLog.counts.<logLevel>` has been added as a shorthand for `events.<logLevel>.length`
- `count()` now accepts an optional log level